### PR TITLE
Feature브랜치로 PR시  NHN containerRepository에 푸시 기능 구현, 유저별 태그조회 로직 변경

### DIFF
--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -1,0 +1,80 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Build and Deploy to Production
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - feature
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Setup PostgreSQL
+        uses: Harmon758/postgresql-action@v1.0.0
+        with:
+          postgresql db: postgres
+          postgresql user: postgres
+          postgresql password: postgres
+
+      - name: Grant execute permission for gradlew # 권한 추가
+        run: chmod +x ./gradlew
+        shell: bash
+
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle # gradle로 빌드
+        run: ./gradlew clean build -Dspring.profiles.active=ci
+        shell: bash
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: 005d9eb7-kr1-registry.container.cloud.toast.com/pickabook-server-prod
+          username: ${{ secrets.NHN_USER_KEY }}
+          password: ${{ secrets.NHN_SECRET_KEY }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: 005d9eb7-kr1-registry.container.cloud.toast.com/pickabook-server-prod/my-container-test:latest
+
+      - name: Get Current Time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DDTHH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Show Current Time
+        run: echo "CurrentTime=${{steps.current-time.outputs.formattedTime}}"
+        shell: bash

--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build with Gradle # gradle로 빌드
-        run: ./gradlew clean build -Dspring.profiles.active=ci
+        run: ./gradlew clean build -Dspring.profiles.active=ci --debug
         shell: bash
 
       - name: Set up Docker Buildx

--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build with Gradle # gradle로 빌드
-        run: ./gradlew clean build -Dspring.profiles.active=ci --info
+        run: ./gradlew clean build -Dspring.profiles.active=ci  -Pjasypt.encryptor.password=${{ secrets.JASYPT_PASSWORD }} --info
         shell: bash
 
       - name: Set up Docker Buildx

--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build with Gradle # gradle로 빌드
-        run: ./gradlew clean build -Dspring.profiles.active=ci --debug
+        run: ./gradlew clean build -Dspring.profiles.active=ci --info
         shell: bash
 
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM adoptopenjdk/openjdk11
+COPY gradlew .
+COPY gradle gladle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar
+
+FROM adoptopenjdk/openjdk11
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+ARG ENVIRONMENT=local
+ENV SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
+
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/controller/BookmarkController.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/controller/BookmarkController.java
@@ -1,13 +1,10 @@
 package beside.sunday8turtle.pickabookserver.modules.bookmark.controller;
 
 import beside.sunday8turtle.pickabookserver.common.response.CommonResponse;
-import beside.sunday8turtle.pickabookserver.modules.bookmark.domain.Tag;
 import beside.sunday8turtle.pickabookserver.modules.bookmark.dto.*;
 import beside.sunday8turtle.pickabookserver.modules.bookmark.service.BookmarkService;
 import beside.sunday8turtle.pickabookserver.modules.user.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -67,9 +64,7 @@ public class BookmarkController {
     @GetMapping("/tags")
     public CommonResponse<List<TagGetResponseDTO>> getTags(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestParam Integer page, @RequestParam Integer size) {
         long userId = principalDetails.getUser().getId();
-        List<Tag> tags = bookmarkService.getTagsByUserId(userId);
-        Page<Tag> pages = new PageImpl<>(tags, PageRequest.of(page, size), tags.size());
-        return CommonResponse.success(TagGetResponseDTO.fromTags(pages));
+        return CommonResponse.success(TagGetResponseDTO.fromTags(bookmarkService.getTagsByUserId(userId, PageRequest.of(page, size))));
     }
 
     @PostMapping("/duplication")

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/domain/Bookmark.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/domain/Bookmark.java
@@ -22,6 +22,7 @@ public class Bookmark extends BaseTimeEntity {
     private String title;
     private String url;
     private String description;
+    private String image;
     private LocalDate notidate;
     @OneToMany(mappedBy = "bookmark", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<BookmarkTag> bookmarkTags = new ArrayList<>();
@@ -29,10 +30,11 @@ public class Bookmark extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private Bookmark(String title, String url, String description, LocalDate notidate, User user) {
+    private Bookmark(String title, String url, String description, String image, LocalDate notidate, User user) {
         this.title = title;
         this.url = url;
         this.description = description;
+        this.image = image;
         this.notidate = notidate;
         this.user = user;
     }
@@ -40,14 +42,15 @@ public class Bookmark extends BaseTimeEntity {
     protected Bookmark() {
     }
 
-    public static Bookmark of(String title, String url, String description, LocalDate notidate, User user) {
-        return new Bookmark(title, url, description, notidate, user);
+    public static Bookmark of(String title, String url, String description, String image, LocalDate notidate, User user) {
+        return new Bookmark(title, url, description, image, notidate, user);
     }
 
     public Bookmark updateBookmark(Bookmark bookmark, BookmarkUpdateRequest updateRequest) {
         updateRequest.getTitleToUpdate().ifPresent(titleToUpdate -> title = titleToUpdate);
         updateRequest.getUrlToUpdate().ifPresent(urlToUpdate -> url = urlToUpdate);
         updateRequest.getDescriptionToUpdate().ifPresent(descriptionToUpdate -> description = descriptionToUpdate);
+        updateRequest.getImageToUpdate().ifPresent(imageToUpdate -> image = imageToUpdate);
         updateRequest.getNotidateToUpdate().ifPresent(notidateToUpdate -> notidate = notidateToUpdate);
         return bookmark;
     }

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkGetResponseDTO.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkGetResponseDTO.java
@@ -21,6 +21,7 @@ public class BookmarkGetResponseDTO {
     private String title;
     private String url;
     private String description;
+    private String image;
     private List<String> tags;
     private LocalDate notidate;
 
@@ -30,6 +31,7 @@ public class BookmarkGetResponseDTO {
                 bookmark.getTitle(),
                 bookmark.getUrl(),
                 bookmark.getDescription(),
+                bookmark.getImage(),
                 bookmark.getBookmarkTags().stream()
                         .map(BookmarkTag::getTag)
                         .map(Tag::getTagName)

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkPostRequestDTO.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkPostRequestDTO.java
@@ -14,6 +14,7 @@ public class BookmarkPostRequestDTO {
         private String title;
         private String url;
         private String description;
+        private String image;
         private List<String> tags;
         private LocalDate notidate;
 }

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkPutRequestDTO.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkPutRequestDTO.java
@@ -16,6 +16,7 @@ public class BookmarkPutRequestDTO {
         private String title;
         private String url;
         private String description;
+        private String image;
         private List<String> tags;
         private LocalDate notidate;
 
@@ -23,6 +24,7 @@ public class BookmarkPutRequestDTO {
                 return builder().titleToUpdate(title)
                         .urlToUpdate(url)
                         .descriptionToUpdate(description)
+                        .imageToUpdate(image)
                         .notidateToUpdate(notidate)
                         .build();
         }

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkUpdateRequest.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/dto/BookmarkUpdateRequest.java
@@ -9,6 +9,7 @@ public class BookmarkUpdateRequest {
     private final String titleToUpdate;
     private final String urlToUpdate;
     private final String descriptionToUpdate;
+    private final String imageToUpdate;
     private final LocalDate notidateToUpdate;
 
     public static BookmarkUpdateRequestBuilder builder() {
@@ -27,6 +28,10 @@ public class BookmarkUpdateRequest {
         return ofNullable(descriptionToUpdate);
     }
 
+    public Optional<String> getImageToUpdate() {
+        return ofNullable(imageToUpdate);
+    }
+
     public Optional<LocalDate> getNotidateToUpdate() {
         return ofNullable(notidateToUpdate);
     }
@@ -35,6 +40,7 @@ public class BookmarkUpdateRequest {
         this.titleToUpdate = builder.titleToUpdate;
         this.urlToUpdate = builder.urlToUpdate;
         this.descriptionToUpdate = builder.descriptionToUpdate;
+        this.imageToUpdate = builder.imageToUpdate;
         this.notidateToUpdate = builder.notidateToUpdate;
     }
 
@@ -42,6 +48,7 @@ public class BookmarkUpdateRequest {
         private String titleToUpdate;
         private String urlToUpdate;
         private String descriptionToUpdate;
+        private String imageToUpdate;
         private LocalDate notidateToUpdate;
 
         public BookmarkUpdateRequestBuilder titleToUpdate(String titleToUpdate) {
@@ -56,6 +63,11 @@ public class BookmarkUpdateRequest {
 
         public BookmarkUpdateRequestBuilder descriptionToUpdate(String descriptionToUpdate) {
             this.descriptionToUpdate = descriptionToUpdate;
+            return this;
+        }
+
+        public BookmarkUpdateRequestBuilder imageToUpdate(String imageToUpdate) {
+            this.imageToUpdate = imageToUpdate;
             return this;
         }
 

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/repository/TagRepository.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/repository/TagRepository.java
@@ -1,7 +1,10 @@
 package beside.sunday8turtle.pickabookserver.modules.bookmark.repository;
 
 import beside.sunday8turtle.pickabookserver.modules.bookmark.domain.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -9,4 +12,7 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     Optional<Tag> findFirstByTagName(String tagName);
 
     void deleteById(Long tagId);
+
+    @Query("select distinct t from Tag t ,BookmarkTag bt, Bookmark b where b.user.id = :userId and b.id = bt.bookmarkId")
+    Page<Tag> findAllTagsByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/service/BookmarkService.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/service/BookmarkService.java
@@ -31,7 +31,7 @@ public class BookmarkService {
     public Bookmark createNewBookmark(long userId, BookmarkPostRequestDTO request) {
         //북마크 객체 생성
         Bookmark bookmark = userService.getUserById(userId)
-                .map(user -> user.addBookmark(request.getTitle(), request.getUrl(), request.getDescription(), request.getNotidate(), user))
+                .map(user -> user.addBookmark(request.getTitle(), request.getUrl(), request.getDescription(), request.getImage(), request.getNotidate(), user))
                 .map(bookmarkRepository::save)
                 .orElseThrow(NoSuchElementException::new);
         //북마크태그, 태그 생성

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/service/BookmarkService.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/service/BookmarkService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -121,15 +120,8 @@ public class BookmarkService {
     }
 
     @Transactional(readOnly = true)
-    public List<Tag> getTagsByUserId(long userId) {
-        //TODO: 태그 중복 제거 필요
-        List<Tag> tagList = new ArrayList<>();
-        List<List<BookmarkTag>> bookmarkTagList = new ArrayList<>();
-        List<Bookmark> bookmarks = userService.getUserById(userId)
-                .map(user -> this.getBookmarksByUserId(user.getId())).orElseThrow(NoSuchElementException::new);
-        bookmarks.forEach(bookmark -> bookmarkTagList.add(bookmarkTagService.findBookmarkTagsByBookmarkId(bookmark.getId())));
-        bookmarkTagList.forEach(bookmarkTags -> bookmarkTags.forEach(bookmarkTag -> tagList.add(bookmarkTag.getTag())));
-        return tagList;
+    public Page<Tag> getTagsByUserId(long userId, Pageable pageable) {
+        return tagService.getTagsByUserId(userId, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/service/TagService.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/bookmark/service/TagService.java
@@ -3,6 +3,8 @@ package beside.sunday8turtle.pickabookserver.modules.bookmark.service;
 import beside.sunday8turtle.pickabookserver.modules.bookmark.domain.Tag;
 import beside.sunday8turtle.pickabookserver.modules.bookmark.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,5 +32,8 @@ public class TagService {
         }));
     }
 
-
+    @Transactional(readOnly = true)
+    Page<Tag> getTagsByUserId(long userId, Pageable pageable) {
+        return tagRepository.findAllTagsByUserId(userId, pageable);
+    }
 }

--- a/src/main/java/beside/sunday8turtle/pickabookserver/modules/user/domain/User.java
+++ b/src/main/java/beside/sunday8turtle/pickabookserver/modules/user/domain/User.java
@@ -4,7 +4,6 @@ import beside.sunday8turtle.pickabookserver.common.entity.BaseTimeEntity;
 import beside.sunday8turtle.pickabookserver.modules.bookmark.domain.Bookmark;
 import lombok.Getter;
 import lombok.ToString;
-import org.hibernate.annotations.ColumnDefault;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
@@ -56,8 +55,8 @@ public class User extends BaseTimeEntity {
         return passwordEncoder.matches(rawPassword, password);
     }
 
-    public Bookmark addBookmark(String title, String url, String description, LocalDate notidate, User user) {
-        return Bookmark.of(title, url, description, notidate, user);
+    public Bookmark addBookmark(String title, String url, String description, String image, LocalDate notidate, User user) {
+        return Bookmark.of(title, url, description, image, notidate, user);
     }
 
     public void enableBrowserNoti() {

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -11,3 +11,18 @@ spring:
       ddl-auto: create
   jwt:
     secret: govlepel@$&
+  redis:
+    host: scat.redistogo.com
+    password: ENC(FnuS29hOJ28uE/g2URiaWmBXZeLdZ1lHBHVDyWE3lrb5JJi2+Xt2fePGa1dYuo6B)
+    port: 10273
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: pickaboookk@gmail.com
+    password: ENC(YtARssZWtpoynITMAQJB7QMCPRIZ7+OggEnJ1KuBYb4=)
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -1,0 +1,28 @@
+spring:
+  profiles:
+    location: ci
+  datasource:
+    username: postgres
+    password: postgres
+    url: jdbc:postgresql://localhost:5432/postgres
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+  jwt:
+    secret: govlepel@$&
+  redis:
+    host: scat.redistogo.com
+    password: ENC(FnuS29hOJ28uE/g2URiaWmBXZeLdZ1lHBHVDyWE3lrb5JJi2+Xt2fePGa1dYuo6B)
+    port: 10273
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: pickaboookk@gmail.com
+    password: ENC(YtARssZWtpoynITMAQJB7QMCPRIZ7+OggEnJ1KuBYb4=)
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -11,18 +11,3 @@ spring:
       ddl-auto: create
   jwt:
     secret: govlepel@$&
-  redis:
-    host: scat.redistogo.com
-    password: ENC(FnuS29hOJ28uE/g2URiaWmBXZeLdZ1lHBHVDyWE3lrb5JJi2+Xt2fePGa1dYuo6B)
-    port: 10273
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: pickaboookk@gmail.com
-    password: ENC(YtARssZWtpoynITMAQJB7QMCPRIZ7+OggEnJ1KuBYb4=)
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true

--- a/src/test/java/beside/sunday8turtle/pickabookserver/PickabookServerApplicationTests.java
+++ b/src/test/java/beside/sunday8turtle/pickabookserver/PickabookServerApplicationTests.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("dev")
+@ActiveProfiles("ci")
 class PickabookServerApplicationTests {
 
 	@Test


### PR DESCRIPTION
### 📌 요약
- 유저별 태그조회 로직 변경
- bookmark 도메인에 image 필드 추가
- 깃헙액션으로 containerRepository에 푸시 하는 기능 구현(feature브랜치)

### 📕 무엇을 작업하셨나요?
- [ ] 버그 수정
- [ ] 기능 개발
- [x] 리팩터링
- [x] 빌드 및 환경설정 관련 작업
- [ ] 그 외의 경우 간략히 기술해주세요

### 📖 변경사항
- deploy-feature.yml 추가
- Dockfile 추가
- application-ci.yml 추가
- 유저별 태그조회 로직 변경
- bookmark 도메인에 image필드 추가

### ✅ 체크리스트
- [ ] 환경변수를 임의로 수정하지 않았나요?
- [ ] 불필요한 로그를 지우셨나요?